### PR TITLE
Fix output streaming as long outputs will block

### DIFF
--- a/AzureSignToolClickOnce/Program.cs
+++ b/AzureSignToolClickOnce/Program.cs
@@ -17,6 +17,7 @@ namespace AzureSignToolClickOnce
             var clientSecret = string.Empty;
             var certName = string.Empty;
 
+
             foreach (string arg in args)
             {
                 if (!arg.StartsWith("-") || arg.Length < 4)


### PR DESCRIPTION
As the description says. If the buffer fills with your current code (and if you have a lot of files in the package it will), then the signer deadlocks. This resolves that